### PR TITLE
Changed out RoutedButton to clean warning in console

### DIFF
--- a/src/RoutedButton.js
+++ b/src/RoutedButton.js
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { matchPath, withRouter } from "react-router";
+import { Button } from "grommet";
+
+// A simple component that shows the pathname of the current location
+class RoutedButton extends React.Component {
+  static propTypes = {
+    location: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired,
+    path: PropTypes.string.isRequired,
+  };
+
+  onClick = event => {
+    const { history, path } = this.props;
+    event.preventDefault();
+    history.push(path);
+  };
+
+  render() {
+    const {
+      active,
+      exact,
+      match,
+      location,
+      history,
+      path,
+      strict,
+      ...rest
+    } = this.props;
+    const pathMatch = matchPath(location.pathname, { exact, path, strict });
+    return (
+      <Button active={active && !!pathMatch} {...rest} onClick={this.onClick} />
+    );
+  }
+}
+
+export default withRouter(RoutedButton);

--- a/src/SandboxComponent.js
+++ b/src/SandboxComponent.js
@@ -1,7 +1,8 @@
 import React from 'react';
 
-import { Box, Grid, RoutedButton } from 'grommet';
+import { Box, Grid } from 'grommet';
 import { Apps } from 'grommet-icons';
+import RoutedButton from './RoutedButton'
 
 const SandboxComponent = props => (
   <Grid>


### PR DESCRIPTION
RoutedButton was being imported from Grommet which is going to be deprecated. It now points to the file RoutedButton