### PR TITLE
Added in same logic for RoutedAnchor & fixed lint errors in Form.js

### DIFF
--- a/src/Form.js
+++ b/src/Form.js
@@ -1,12 +1,11 @@
 import React from "react";
 import {
-  Box,
   Button,
   CheckBox,
   Form,
   FormField,
   RadioButtonGroup,
-  Select
+  Select,
 } from "grommet";
 import SandboxComponent from "./SandboxComponent";
 

--- a/src/Home.js
+++ b/src/Home.js
@@ -1,7 +1,7 @@
 import React from 'react';
 
-import { Box, Grid, Heading, RoutedAnchor } from 'grommet';
-// import RoutedAnchor from './RoutedAnchor';
+import { Box, Grid, Heading } from 'grommet';
+import RoutedAnchor from './RoutedAnchor';
 
 export default () => (
   <Box pad='large'>

--- a/src/Home.js
+++ b/src/Home.js
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Box, Grid, Heading, RoutedAnchor } from 'grommet';
+// import RoutedAnchor from './RoutedAnchor';
 
 export default () => (
   <Box pad='large'>

--- a/src/RoutedAnchor.js
+++ b/src/RoutedAnchor.js
@@ -1,0 +1,38 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { matchPath, withRouter } from "react-router";
+import { Anchor } from "grommet";
+
+// A simple component that shows the pathname of the current location
+class RoutedAnchor extends React.Component {
+  static propTypes = {
+    location: PropTypes.object.isRequired,
+    history: PropTypes.object.isRequired,
+    path: PropTypes.string.isRequired,
+  };
+
+  onClick = event => {
+    const { history, path } = this.props;
+    event.preventDefault();
+    history.push(path);
+  };
+
+  render() {
+    const {
+      active,
+      exact,
+      match,
+      location,
+      history,
+      path,
+      strict,
+      ...rest
+    } = this.props;
+    const pathMatch = matchPath(location.pathname, { exact, path, strict });
+    return (
+      <Anchor active={active && !!pathMatch} {...rest} onClick={this.onClick} />
+    );
+  }
+}
+
+export default withRouter(RoutedAnchor);


### PR DESCRIPTION
Used the same logic to replace RoutedAnchor that was being imported from Grommet. 
Also fixed some lint errors that appeared in Form.js 
