### PR TITLE
disableHostCheckTrue

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,7 @@ module.exports = {
     contentBase: './dist',
     historyApiFallback: true,
     port: 8576,
+    disableHostCheck: true,
   },
   entry: './src/index.js',
   output: {


### PR DESCRIPTION
added disablehostcheck: true to webpack config. will fix link issue after links are updated in the grommet site repository